### PR TITLE
Add option to render directly on logout sidestone instead of infobox - Closes #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.4'
+def runeLiteVersion = '1.8.24.3'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'im2be.afkcountdown'
-version = '1.1'
+version = '1.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/im2be/afkcountdown/AfkCountdownConfig.java
+++ b/src/main/java/im2be/afkcountdown/AfkCountdownConfig.java
@@ -1,0 +1,21 @@
+package im2be.afkcountdown;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(AfkCountdownConfig.GROUP)
+public interface AfkCountdownConfig  extends Config {
+
+    String GROUP = "AfkCountdown";
+
+    @ConfigItem(
+            keyName = "renderOnLogoutStone",
+            name = "Render on logout stone",
+            description = "Disable for infobox, enable for text overlay on logout tab stone"
+    )
+    default boolean renderOnLogoutStone() {
+        return false;
+    }
+
+}

--- a/src/main/java/im2be/afkcountdown/AfkCountdownOverlay.java
+++ b/src/main/java/im2be/afkcountdown/AfkCountdownOverlay.java
@@ -1,0 +1,88 @@
+package im2be.afkcountdown;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.FontType;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.client.ui.overlay.OverlayUtil;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Slf4j
+public class AfkCountdownOverlay extends Overlay {
+
+    private final Client client;
+    private final AfkCountdownConfig config;
+    private final ConfigManager configManager;
+
+    private Instant endTime;
+
+    @Inject
+    public AfkCountdownOverlay(Client client, AfkCountdownPlugin plugin, AfkCountdownConfig config, ConfigManager configManager) {
+        super(plugin);
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setPriority(OverlayPriority.HIGH);
+        this.client = client;
+        this.config = config;
+        this.configManager = configManager;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (!config.renderOnLogoutStone()) return null;
+
+        Widget toDrawOn;
+        if (client.isResized()) {
+            toDrawOn = client.getWidget(WidgetInfo.RESIZABLE_VIEWPORT_LOGOUT_TAB);
+            if (toDrawOn == null || toDrawOn.isHidden())
+                toDrawOn = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_LOGOUT_BUTTON);
+        } else {
+            toDrawOn = client.getWidget(WidgetInfo.FIXED_VIEWPORT_LOGOUT_TAB);
+        }
+        if (toDrawOn == null || toDrawOn.isHidden()) return null;
+
+        Duration timeLeft = Duration.between(Instant.now(), endTime);
+        if (timeLeft.isNegative()) return null;
+
+        String textToDraw = textFrom(timeLeft);
+        FontType infoboxFontType = configManager.getConfiguration("runelite", "infoboxFontType", FontType.class);
+        graphics.setFont(infoboxFontType.getFont()); // make sure we do this before calculating drawLocation
+
+        Rectangle bounds = toDrawOn.getBounds();
+        Point drawLocation = new Point((int) bounds.getCenterX() - (graphics.getFontMetrics().stringWidth(textToDraw) / 2), (int) bounds.getMaxY());
+        OverlayUtil.renderTextLocation(graphics, drawLocation, textToDraw, textColor(timeLeft));
+
+        return null;
+    }
+
+    public void setTimer(long period) {
+        endTime = Instant.now().plus(Duration.of(period, ChronoUnit.MILLIS));
+    }
+
+    private Color textColor(Duration timeLeft) {
+        if (timeLeft.getSeconds() < 60)
+            return Color.RED.brighter();
+        return Color.WHITE;
+    }
+
+    private String textFrom(Duration duration) {
+        int seconds = (int) (duration.toMillis() / 1000L);
+
+        int minutes = (seconds % 3600) / 60;
+        int secs = seconds % 60;
+
+        return String.format("%d:%02d", minutes, secs);
+    }
+}

--- a/src/main/java/im2be/afkcountdown/AfkCountdownPlugin.java
+++ b/src/main/java/im2be/afkcountdown/AfkCountdownPlugin.java
@@ -2,15 +2,19 @@ package im2be.afkcountdown;
 
 import javax.inject.Inject;
 
+import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ImageUtil;
 import java.awt.image.BufferedImage;
@@ -40,6 +44,15 @@ public class AfkCountdownPlugin extends Plugin
 	@Inject
 	private InfoBoxManager infoBoxManager;
 
+	@Inject
+	private AfkCountdownOverlay overlay;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private AfkCountdownConfig config;
+
 	private static final BufferedImage LOGOUT_IMAGE;
 	private boolean active = false;
 
@@ -54,6 +67,8 @@ public class AfkCountdownPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		active = true;
+		if (config.renderOnLogoutStone())
+			overlayManager.add(overlay);
 	}
 
 	@Override
@@ -62,8 +77,31 @@ public class AfkCountdownPlugin extends Plugin
 		active = false;
 		lastIdleTicks = -1;
 		removeTimer();
+		overlayManager.remove(overlay);
 	}
 
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event) {
+		if (!AfkCountdownConfig.GROUP.equals(event.getGroup())) return;
+
+		if ("renderOnLogoutStone".equals(event.getKey())) {
+			if (config.renderOnLogoutStone()) {
+				overlayManager.add(overlay);
+				removeTimer();
+			} else {
+				overlayManager.remove(overlay);
+
+				// emulate infobox timer creation similar to onClientTick does
+				final long durationMillis = (AFK_LOG_TICKS - getIdleTicks()) * AFK_LOG_TIME.toMillis() / AFK_LOG_TICKS + 999;
+				setTimer(Duration.ofMillis(durationMillis));
+			}
+		}
+	}
+
+	@Provides
+	AfkCountdownConfig provideConfig(ConfigManager configManager) {
+		return configManager.getConfig(AfkCountdownConfig.class);
+	}
 
 	private int getIdleTicks()
 	{
@@ -99,6 +137,7 @@ public class AfkCountdownPlugin extends Plugin
 			if (durationMillis >= 0)
 			{
 				setTimer(Duration.ofMillis(durationMillis));
+				overlay.setTimer(durationMillis);
 			}
 			else
 			{
@@ -129,6 +168,8 @@ public class AfkCountdownPlugin extends Plugin
 
 	private void setTimer(Duration duration)
 	{
+		if (config.renderOnLogoutStone()) return;
+
 		final Instant now = Instant.now();
 		if (currentTimer == null)
 		{


### PR DESCRIPTION
Default config will still show infobox, not directly on the logout stone. Toggling the config option will remove the infobox and start rendering direct on the logout stone instead. This can be toggled back and forth freely.

The time readout, the font, and the colour used will be the same as the infobox text would be.