### PR TITLE
Continue to display while bank is open (and similar situations) in resizable classic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.33'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/im2be/afkcountdown/AfkCountdownOverlay.java
+++ b/src/main/java/im2be/afkcountdown/AfkCountdownOverlay.java
@@ -45,9 +45,18 @@ public class AfkCountdownOverlay extends Overlay {
 
         Widget toDrawOn;
         if (client.isResized()) {
+
+            // Default to classic layout logout button
             toDrawOn = client.getWidget(WidgetInfo.RESIZABLE_VIEWPORT_LOGOUT_TAB);
+
+            // else try classic while-bank-is-open logout button (or where it would be, at least)
+            if (toDrawOn == null || toDrawOn.isHidden())
+                toDrawOn = client.getWidget(WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_PARENT);
+
+            // else try logout button next to minimap for modern layout
             if (toDrawOn == null || toDrawOn.isHidden())
                 toDrawOn = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_LOGOUT_BUTTON);
+
         } else {
             toDrawOn = client.getWidget(WidgetInfo.FIXED_VIEWPORT_LOGOUT_TAB);
         }


### PR DESCRIPTION
This isn't a problem for modern layout as the X button doesn't get hidden in the bank (or if some other interface is open), but classic layout the logout tab widget is hidden, so this now uses the widget that remains when bank is open. This does mean that when you open the bank, the overlay does shift its position by a pixel or two, but that's a lot better than not showing at all in the bank!

Also runeLiteVersion is now `latest.release` so it will automatically just use the most recent release when running locally